### PR TITLE
Release 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,32 +6,28 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-### Language Support
+## [0.0.5] - 2024-09-18
 
-- Add initial support for Python
+### Added
 
-### Visualization
+- Initial support for Python.
+- Support for node clusters. This is used heavily in Python, for context-managers and exception-handling.
+- A "share" feature to the demo
+- A "save SVG" option to the demo
 
-- Add support for node clusters. This is used heavily in Python, for context-managers and exception-handling.
-
-### Demo
-
-- Add Python support
-- Add sharing - click the "Share" button to get a sharable link to what you currently see
-
-### Testing
+#### Testing
 
 - Enable live-testing with the web viewer. Requires that you run both `bun web-tests --watch` and `bun web` at the same time.
 - By default, `bun web` only shows failing tests
 - `bun web` color-codes tests to note which are failing
+- `bun lint` added `tsc --noEmit`
+- DOT output in `bun web` is not pretty-printed, and can be automatically opened in [GraphvizOnline](https://dreampuf.github.io/GraphvizOnline/)
 
-### Extension
+### Fixed
 
-- No changes
-
-### Known Issues
-
-- Backlinks are no longer thicker than normal links. That said, they were half-broken to begin with and were somewhat arbitrary.
+- Switch-like structures in flatSwitch now show an alternative edge from the head to the exit node.
+  This was previously missing.
+- Thick-backlinks (for loops) are now generated correctly based on loop detection.
 
 ## [0.0.4] - 2024-09-10
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@ Note that the demo only supports a single function and ignores the cursor locati
 
 ## Supported Languages
 
-- Go
-- C
-- Python (experimental, only in the [interactive demo](https://tmr232.github.io/function-graph-overview/?language=2))
-  - Since this adds _a lot_ of new visualization types, this is marked "experimental"
-    as it is very likely to change.
+- [Go](https://tmr232.github.io/function-graph-overview/?language=0)
+- [C](https://tmr232.github.io/function-graph-overview/?language=1)
+- [Python](https://tmr232.github.io/function-graph-overview/?language=2)
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "//": "START EXTENSION ATTRIBUTES",
   "publisher": "tamir-bahar",
   "name": "function-graph-overview",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Function Graph Overview",
   "displayName": "Function Graph Overview",
   "icon": "./media/icon.png",

--- a/src/vscode/extension.ts
+++ b/src/vscode/extension.ts
@@ -6,6 +6,7 @@ import { Graphviz } from "@hpcc-js/wasm-graphviz";
 import { graphToDot } from "../control-flow/render";
 import { simplifyCFG, trimFor } from "../control-flow/graph-ops";
 import { newCFGBuilder, type Language } from "../control-flow/cfg";
+import { mergeNodeAttrs } from "../control-flow/cfg-defs";
 
 let graphviz: Graphviz;
 interface SupportedLanguage {
@@ -24,11 +25,17 @@ const supportedLanguages: SupportedLanguage[] = [
     language: "Go" as Language,
     parserName: "tree-sitter-go.wasm",
   },
+  {
+    languageId: "python",
+    language: "Python" as Language,
+    parserName: "tree-sitter-python.wasm",
+  },
 ];
 
 const functionNodeTypes: { [key: string]: string[] } = {
   go: ["function_declaration", "method_declaration", "func_literal"],
   c: ["function_definition"],
+  python: ["function_definition"],
 };
 
 const supportedLanguageIds = supportedLanguages.map((lang) => lang.languageId);
@@ -176,7 +183,7 @@ export async function activate(context: vscode.ExtensionContext) {
             .getConfiguration("functionGraphOverview")
             .get("simplify")
         ) {
-          cfg = simplifyCFG(cfg);
+          cfg = simplifyCFG(cfg, mergeNodeAttrs);
         }
         const dot = graphToDot(cfg);
         const svg = graphviz.dot(dot);
@@ -189,7 +196,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }
 
 //------------------------------------------------
 
@@ -198,7 +205,7 @@ class OverviewViewProvider implements vscode.WebviewViewProvider {
 
   private _view?: vscode.WebviewView;
 
-  constructor(private readonly _extensionUri: vscode.Uri) {}
+  constructor(private readonly _extensionUri: vscode.Uri) { }
 
   public setSVG(svg: string) {
     if (this._view) {


### PR DESCRIPTION
### Added

- Initial support for Python.
- Support for node clusters. This is used heavily in Python, for context-managers and exception-handling.
- A "share" feature to the demo
- A "save SVG" option to the demo

#### Testing

- Enable live-testing with the web viewer. Requires that you run both `bun web-tests --watch` and `bun web` at the same time.
- By default, `bun web` only shows failing tests
- `bun web` color-codes tests to note which are failing
- `bun lint` added `tsc --noEmit`
- DOT output in `bun web` is not pretty-printed, and can be automatically opened in [GraphvizOnline](https://dreampuf.github.io/GraphvizOnline/)

### Fixed

- Switch-like structures in flatSwitch now show an alternative edge from the head to the exit node.
  This was previously missing.
- Thick-backlinks (for loops) are now generated correctly based on loop detection.