### PR TITLE
render-page: Fix GitHub URL parsing

### DIFF
--- a/src/render/src/App.svelte
+++ b/src/render/src/App.svelte
@@ -55,7 +55,7 @@
     }
 
     const rawUrl = githubURL.replace(
-      /(?<host>https:\/\/github.com\/)(?<project>\w+\/\w+\/)(blob\/)(?<path>.*)(#L\d+)/,
+      /(?<host>https:\/\/github.com\/)(?<project>[^/]+\/[^/]+\/)(blob\/)(?<path>.*)(#L\d+)/,
       "https://raw.githubusercontent.com/$<project>$<path>",
     );
 


### PR DESCRIPTION
Removes assumptions about user and project names.
