### PR TITLE
render-page: Fix the open-code button

### DIFF
--- a/src/render/src/App.svelte
+++ b/src/render/src/App.svelte
@@ -149,7 +149,14 @@
 
     if (githubUrl) {
       const { line, rawUrl } = parseGithubUrl(githubUrl);
-      return { type: "GitHub", rawUrl, line, colorScheme, colors, codeUrl };
+      return {
+        type: "GitHub",
+        rawUrl,
+        line,
+        colorScheme,
+        colors,
+        codeUrl: githubUrl,
+      };
     }
     return {
       type: "Graph",


### PR DESCRIPTION
No longer disabled for GitHub code
