### PR TITLE
cfg: Removed unnecessary null-cases

### DIFF
--- a/src/control-flow/block-matcher.ts
+++ b/src/control-flow/block-matcher.ts
@@ -68,7 +68,7 @@ function getSyntaxMany(
 
 export class BlockMatcher {
   private blockHandler: BlockHandler = new BlockHandler();
-  private dispatchSingle: (syntax: Parser.SyntaxNode | null) => BasicBlock;
+  private dispatchSingle: (syntax: Parser.SyntaxNode) => BasicBlock;
   public update = this.blockHandler.update.bind(this.blockHandler);
 
   constructor(dispatchSingle: BlockMatcher["dispatchSingle"]) {

--- a/src/control-flow/builder.ts
+++ b/src/control-flow/builder.ts
@@ -62,11 +62,7 @@ export class Builder {
    * @param code
    * @param startOffset The offset in the code for which the node is generated
    */
-  public addNode(
-    type: NodeType,
-    code: string,
-    startOffset: number | null,
-  ): string {
+  public addNode(type: NodeType, code: string, startOffset: number): string {
     const id = `node${this.nodeId++}`;
     const cluster = this.activeClusters[this.activeClusters.length - 1];
     this.graph.addNode(id, {

--- a/src/control-flow/cfg-defs.ts
+++ b/src/control-flow/cfg-defs.ts
@@ -58,7 +58,7 @@ export interface GraphNode {
   markers: string[];
   cluster?: Cluster;
   targets: string[];
-  startOffset: number | null;
+  startOffset: number;
 }
 
 export interface GraphEdge {
@@ -274,12 +274,7 @@ export function mergeNodeAttrs(
     return null;
   }
 
-  const startOffset = (() => {
-    if (from.startOffset === null || into.startOffset === null) {
-      return from.startOffset ?? into.startOffset;
-    }
-    return Math.min(from.startOffset, into.startOffset);
-  })();
+  const startOffset = Math.min(from.startOffset, into.startOffset);
 
   return {
     type: from.type,

--- a/src/control-flow/common-patterns.ts
+++ b/src/control-flow/common-patterns.ts
@@ -495,8 +495,7 @@ export function processStatementSequence(
   syntax: Parser.SyntaxNode,
   ctx: Context,
 ): BasicBlock {
-  const blockBlock = ctx.dispatch.many(syntax.namedChildren);
-  ctx.builder.setDefault(blockBlock.entry, { startOffset: syntax.startIndex });
+  const blockBlock = ctx.dispatch.many(syntax.namedChildren, syntax);
   ctx.link.syntaxToNode(syntax, blockBlock.entry);
   return blockBlock;
 }

--- a/src/control-flow/switch-utils.ts
+++ b/src/control-flow/switch-utils.ts
@@ -100,7 +100,9 @@ export function collectCases(
     );
     ctx.link.syntaxToNode(caseSyntax, conditionNode);
 
-    const consequenceBlock = ctx.state.update(ctx.dispatch.many(consequence));
+    const consequenceBlock = ctx.state.update(
+      ctx.dispatch.many(consequence, caseSyntax),
+    );
     if (consequence.length > 0) {
       ctx.link.offsetToSyntax(
         ctx.matcher

--- a/src/vscode/extension.ts
+++ b/src/vscode/extension.ts
@@ -305,10 +305,8 @@ export async function activate(context: vscode.ExtensionContext) {
   function onNodeClick(node: string): void {
     if (!savedCFG) return;
     const offset = savedCFG.graph.getNodeAttribute(node, "startOffset");
-    if (offset !== null) {
-      moveCursorAndReveal(offset);
-      focusEditor();
-    }
+    moveCursorAndReveal(offset);
+    focusEditor();
   }
 
   context.subscriptions.push(


### PR DESCRIPTION
- `GraphNode` always requires a `startOffset`. If one is missing (in the case of empty blocks), we use the parent's `startOffset` instead.
- `dispatchSingle` no longer takes `null` as an input. This was not actually used anywhere, and just complicated the code.
