### PR TITLE
Remove APIs not supported by Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Methods are now supported in TypeScript.
 - `continue label` is now supported in Go.
 - Exporting DOT files (in debug mode) no longer results in different-looking graphs
+- The web renderer now supports iOS browsers.
 
 ### Changed
 

--- a/src/components/CodeSegmentation.svelte
+++ b/src/components/CodeSegmentation.svelte
@@ -35,7 +35,7 @@
   type NodeColors = Map<string, string>;
 
   function createNodeColors(cfg: CFG): Map<string, string> {
-    const nodes = new Set(cfg.offsetToNode.iter().map(({ value }) => value));
+    const nodes = new Set(cfg.offsetToNode.values());
     const nodeColors = new Map(
       [...nodes.keys()].map((node, i, { length }) => [
         node,

--- a/src/control-flow/ranges.ts
+++ b/src/control-flow/ranges.ts
@@ -99,11 +99,11 @@ export class Lookup<T> {
 
   public mapValues<U>(fn: (value: T) => U): Lookup<U> {
     const lookup = new Lookup(fn(this.get(0)));
-    lookup.ranges = Array.from(
-      this[Symbol.iterator]().map(({ start, value }) => ({
+    lookup.ranges = Array.from(iterRanges(this.ranges)).map(
+      ({ start, value }) => ({
         start,
         value: fn(value),
-      })),
+      }),
     );
     return lookup;
   }
@@ -112,8 +112,8 @@ export class Lookup<T> {
     return iterRanges(this.ranges);
   }
 
-  public iter() {
-    return this[Symbol.iterator]();
+  public values(): T[] {
+    return Array.from(iterRanges(this.ranges)).map(({ value }) => value);
   }
 
   public clone(): Lookup<T> {


### PR DESCRIPTION
Specifically, we remove the use of `Generator.map`, as it is not yet supported on Safari on iOS.

Closes #93
