### PR TITLE
issue 111 finally after throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Comment-tests now fail if an unsupported test type is present instead of passing silently.
 - Python `match` statements no longer break when a comment is present at their top-level
+- `throw` and `raise` statements now cause `finally` block duplication like `return` statements.
 
 ### Changed
 

--- a/src/control-flow/cfg-python.ts
+++ b/src/control-flow/cfg-python.ts
@@ -93,7 +93,7 @@ function processAssertStatement(
   ctx.builder.addEdge(conditionNode, raiseNode, "alternative");
   ctx.builder.addEdge(conditionNode, happyNode, "consequence");
 
-  return { entry: conditionNode, exit: happyNode };
+  return { entry: conditionNode, exit: happyNode, functionExits: [raiseNode] };
 }
 
 function processRaiseStatement(
@@ -107,7 +107,7 @@ function processRaiseStatement(
     raiseSyntax.startIndex,
   );
   ctx.link.syntaxToNode(raiseSyntax, raiseNode);
-  return { entry: raiseNode, exit: null };
+  return { entry: raiseNode, exit: null, functionExits: [raiseNode] };
 }
 function processReturnStatement(
   returnSyntax: Parser.SyntaxNode,
@@ -128,8 +128,8 @@ function processTryStatement(
 ): BasicBlock {
   const { builder, matcher } = ctx;
   /*
-  Here's an idea - I can duplicate the finally blocks!
-  Then if there's a return, I stick the finally before it.
+  Here's an idea - I can duplicate the `finally` blocks!
+  Then, if there's a function-exit, I stick the `finally` before it.
   In other cases, the finally is after the end of the try-body.
   This is probably the best course of action.
   */
@@ -192,33 +192,33 @@ function processTryStatement(
     }
 
     const finallyBlock = builder.withCluster("finally", () => {
-      // Handle all the return statements from the try block
+      // Handle all the function-exit statements from the try block
       if (finallySyntax) {
         // This is only relevant if there's a finally block.
-        matcher.state.forEachFunctionExit((returnNode) => {
-          // We create a new finally block for each return node,
+        matcher.state.forEachFunctionExit((functionExitNode) => {
+          // We create a new finally block for each function-exit node,
           // so that we can link them.
           const duplicateFinallyBlock = match.getBlock(finallySyntax);
-          // We also clone the return node, to place it _after_ the finally block
+          // We also clone the function-exit node, to place it _after_ the finally block
           // We also override the cluster node, pulling it up to the `try-complex`,
-          // as the return is neither in a `try`, `except`, or `finally` context.
-          const returnNodeClone = builder.cloneNode(returnNode, {
+          // as the function-exit is neither in a `try`, `except`, or `finally` context.
+          const functionExitCloneNode = builder.cloneNode(functionExitNode, {
             cluster: tryComplexCluster,
           });
 
-          builder.addEdge(returnNode, duplicateFinallyBlock.entry);
+          builder.addEdge(functionExitNode, duplicateFinallyBlock.entry);
           if (duplicateFinallyBlock.exit)
-            builder.addEdge(duplicateFinallyBlock.exit, returnNodeClone);
+            builder.addEdge(duplicateFinallyBlock.exit, functionExitCloneNode);
 
-          // We return the cloned return node as the new return node, in case we're nested
-          // in a scope that will process it.
-          return returnNodeClone;
+          // We return the cloned function-exit node as the new function-exit node,
+          // in case we're nested in a scope that will process it.
+          return functionExitCloneNode;
         });
       }
 
       // Handle the finally-block for the trivial case, where we just pass through the try block
-      // This must happen AFTER handling the return statements, as the finally block may add return
-      // statements of its own.
+      // This must happen AFTER handling the function-exit statements,
+      // as the finally block may add function-exit statements of its own.
       const finallyBlock = match.getBlock(finallySyntax);
       return finallyBlock;
     });

--- a/src/control-flow/cfg-python.ts
+++ b/src/control-flow/cfg-python.ts
@@ -120,7 +120,7 @@ function processReturnStatement(
     returnSyntax.startIndex,
   );
   ctx.link.syntaxToNode(returnSyntax, returnNode);
-  return { entry: returnNode, exit: null, returns: [returnNode] };
+  return { entry: returnNode, exit: null, functionExits: [returnNode] };
 }
 function processTryStatement(
   trySyntax: Parser.SyntaxNode,
@@ -195,7 +195,7 @@ function processTryStatement(
       // Handle all the return statements from the try block
       if (finallySyntax) {
         // This is only relevant if there's a finally block.
-        matcher.state.forEachReturn((returnNode) => {
+        matcher.state.forEachFunctionExit((returnNode) => {
           // We create a new finally block for each return node,
           // so that we can link them.
           const duplicateFinallyBlock = match.getBlock(finallySyntax);

--- a/src/control-flow/cfg-typescript.ts
+++ b/src/control-flow/cfg-typescript.ts
@@ -247,7 +247,7 @@ function processTryStatement(
       // Handle all the return statements from the try block
       if (finallySyntax) {
         // This is only relevant if there's a finally block.
-        matcher.state.forEachReturn((returnNode) => {
+        matcher.state.forEachFunctionExit((returnNode) => {
           // We create a new finally block for each return node,
           // so that we can link them.
           const duplicateFinallyBlock = match.getBlock(finallySyntax);

--- a/src/control-flow/cfg-typescript.ts
+++ b/src/control-flow/cfg-typescript.ts
@@ -193,8 +193,8 @@ function processTryStatement(
 ): BasicBlock {
   const { builder, matcher } = ctx;
   /*
-  Here's an idea - I can duplicate the finally blocks!
-  Then if there's a return, I stick the finally before it.
+  Here's an idea - I can duplicate the `finally` blocks!
+  Then, if there's a function-exit, I stick the `finally` before it.
   In other cases, the finally is after the end of the try-body.
   This is probably the best course of action.
   */
@@ -244,33 +244,33 @@ function processTryStatement(
     }
 
     const finallyBlock = builder.withCluster("finally", () => {
-      // Handle all the return statements from the try block
+      // Handle all the function-exit statements from the try block
       if (finallySyntax) {
         // This is only relevant if there's a finally block.
         matcher.state.forEachFunctionExit((returnNode) => {
-          // We create a new finally block for each return node,
+          // We create a new finally block for each function-exit node,
           // so that we can link them.
           const duplicateFinallyBlock = match.getBlock(finallySyntax);
-          // We also clone the return node, to place it _after_ the finally block
+          // We also clone the function-exit node, to place it _after_ the finally block
           // We also override the cluster node, pulling it up to the `try-complex`,
-          // as the return is neither in a `try`, `except`, or `finally` context.
-          const returnNodeClone = builder.cloneNode(returnNode, {
+          // as the function-exit is neither in a `try`, `except`, or `finally` context.
+          const functionExitCloneNode = builder.cloneNode(returnNode, {
             cluster: tryComplexCluster,
           });
 
           builder.addEdge(returnNode, duplicateFinallyBlock.entry);
           if (duplicateFinallyBlock.exit)
-            builder.addEdge(duplicateFinallyBlock.exit, returnNodeClone);
+            builder.addEdge(duplicateFinallyBlock.exit, functionExitCloneNode);
 
-          // We return the cloned return node as the new return node, in case we're nested
-          // in a scope that will process it.
-          return returnNodeClone;
+          // We return the cloned return node as the new function-exit node,
+          // in case we're nested in a scope that will process it.
+          return functionExitCloneNode;
         });
       }
 
       // Handle the finally-block for the trivial case, where we just pass through the try block
-      // This must happen AFTER handling the return statements, as the finally block may add return
-      // statements of its own.
+      // This must happen AFTER handling the function-exit statements,
+      // as the finally block may add function-exit statements of its own.
       const finallyBlock = match.getBlock(finallySyntax);
       return finallyBlock;
     });

--- a/src/control-flow/common-patterns.ts
+++ b/src/control-flow/common-patterns.ts
@@ -565,5 +565,5 @@ export function processThrowStatement(
     throwSyntax.startIndex,
   );
   ctx.link.syntaxToNode(throwSyntax, throwNode);
-  return { entry: throwNode, exit: null };
+  return { entry: throwNode, exit: null, functionExits: [throwNode] };
 }

--- a/src/test/__snapshots__/commentTest.test.ts.snap
+++ b/src/test/__snapshots__/commentTest.test.ts.snap
@@ -18004,3 +18004,207 @@ Lookup {
   ],
 }
 `;
+
+exports[`Python: issue-111-throw-finally.py!raise_and_finally: DOT Snapshot 1`] = `
+"digraph "" {
+    node [shape=box, color="#000000"];
+    edge [headport=n tailport=s]
+    bgcolor="#ffffff"
+    subgraph cluster_0 {
+        penwidth=0; color="#ffffff"; bgcolor="#ddddff"; class="tryComplex"
+        node4 [style="filled"; label=""; id="node4"; shape="triangle"; class="throw"; fillcolor="#ffdddd"; height=0.5];
+        subgraph cluster_1 {
+            penwidth=0; color="#ffffff"; bgcolor="#ddffdd"; class="try"
+            node2 [style="filled"; label=""; id="node2"; shape="triangle"; class="throw"; fillcolor="#ffdddd"; height=0.3];
+        }
+        subgraph cluster_2 {
+            penwidth=0; color="#ffffff"; bgcolor="#ffffdd"; class="finally"
+            node3 [style="filled"; label=""; id="node3"; shape="box"; class="default"; fillcolor="#d3d3d3"; height=0.3];
+        }
+    }
+    node0 [style="filled"; label=""; id="node0"; shape="invhouse"; class="entry"; fillcolor="#48AB30"; height=0.5];
+    node2 [style="filled"; label=""; id="node2"; shape="triangle"; class="throw"; fillcolor="#ffdddd"; height=0.3];
+    node3 [style="filled"; label=""; id="node3"; shape="box"; class="default"; fillcolor="#d3d3d3"; height=0.3];
+    node4 [style="filled"; label=""; id="node4"; shape="triangle"; class="throw"; fillcolor="#ffdddd"; height=0.5];
+    node2 -> node3 [penwidth=1; color="#0000ff"; class="regular"];
+    node3 -> node4 [penwidth=1; color="#0000ff"; class="regular"];
+    node0 -> node2 [penwidth=1; color="#0000ff"; class="regular"];
+}"
+`;
+
+exports[`TypeScript: issue-111-throw-finally.ts!throwAndFinally: DOT Snapshot 1`] = `
+"digraph "" {
+    node [shape=box, color="#000000"];
+    edge [headport=n tailport=s]
+    bgcolor="#ffffff"
+    subgraph cluster_0 {
+        penwidth=0; color="#ffffff"; bgcolor="#ddddff"; class="tryComplex"
+        node4 [style="filled"; label=""; id="node4"; shape="triangle"; class="throw"; fillcolor="#ffdddd"; height=0.5];
+        subgraph cluster_1 {
+            penwidth=0; color="#ffffff"; bgcolor="#ddffdd"; class="try"
+            node2 [style="filled"; label=""; id="node2"; shape="triangle"; class="throw"; fillcolor="#ffdddd"; height=0.3];
+        }
+        subgraph cluster_3 {
+            penwidth=0; color="#ffffff"; bgcolor="#ffffdd"; class="finally"
+            node3 [style="filled"; label=""; id="node3"; shape="box"; class="default"; fillcolor="#d3d3d3"; height=0.3];
+        }
+    }
+    node0 [style="filled"; label=""; id="node0"; shape="invhouse"; class="entry"; fillcolor="#48AB30"; height=0.5];
+    node2 [style="filled"; label=""; id="node2"; shape="triangle"; class="throw"; fillcolor="#ffdddd"; height=0.3];
+    node3 [style="filled"; label=""; id="node3"; shape="box"; class="default"; fillcolor="#d3d3d3"; height=0.3];
+    node4 [style="filled"; label=""; id="node4"; shape="triangle"; class="throw"; fillcolor="#ffdddd"; height=0.5];
+    node2 -> node3 [penwidth=1; color="#0000ff"; class="regular"];
+    node3 -> node4 [penwidth=1; color="#0000ff"; class="regular"];
+    node0 -> node2 [penwidth=1; color="#0000ff"; class="regular"];
+}"
+`;
+
+exports[`Python: issue-111-throw-finally.py!raise_and_finally: Segmentation 1`] = `
+Lookup {
+  "ranges": [
+    {
+      "start": 0,
+      "value": "node0",
+    },
+    {
+      "start": 23,
+      "value": "node0",
+    },
+    {
+      "start": 52,
+      "value": "node4",
+    },
+    {
+      "start": 65,
+      "value": "node4",
+    },
+    {
+      "start": 85,
+      "value": "node4",
+    },
+    {
+      "start": 85,
+      "value": "node4",
+    },
+    {
+      "start": 90,
+      "value": "node5",
+    },
+    {
+      "start": 107,
+      "value": "node5",
+    },
+    {
+      "start": 122,
+      "value": "node5",
+    },
+    {
+      "start": 122,
+      "value": "node5",
+    },
+    {
+      "start": 122,
+      "value": "node5",
+    },
+    {
+      "start": 122,
+      "value": "node5",
+    },
+    {
+      "start": 122,
+      "value": "node4",
+    },
+    {
+      "start": 122,
+      "value": "node0",
+    },
+    {
+      "start": 122,
+      "value": "node4",
+    },
+    {
+      "start": 122,
+      "value": "node0",
+    },
+  ],
+}
+`;
+
+exports[`TypeScript: issue-111-throw-finally.ts!throwAndFinally: Segmentation 1`] = `
+Lookup {
+  "ranges": [
+    {
+      "start": 0,
+      "value": "node0",
+    },
+    {
+      "start": 26,
+      "value": "node0",
+    },
+    {
+      "start": 57,
+      "value": "node4",
+    },
+    {
+      "start": 61,
+      "value": "node4",
+    },
+    {
+      "start": 67,
+      "value": "node4",
+    },
+    {
+      "start": 84,
+      "value": "node4",
+    },
+    {
+      "start": 88,
+      "value": "node4",
+    },
+    {
+      "start": 89,
+      "value": "node5",
+    },
+    {
+      "start": 97,
+      "value": "node5",
+    },
+    {
+      "start": 103,
+      "value": "node5",
+    },
+    {
+      "start": 124,
+      "value": "node5",
+    },
+    {
+      "start": 124,
+      "value": "node5",
+    },
+    {
+      "start": 128,
+      "value": "node5",
+    },
+    {
+      "start": 128,
+      "value": "node5",
+    },
+    {
+      "start": 128,
+      "value": "node4",
+    },
+    {
+      "start": 128,
+      "value": "node4",
+    },
+    {
+      "start": 130,
+      "value": "node0",
+    },
+    {
+      "start": 130,
+      "value": "node0",
+    },
+  ],
+}
+`;

--- a/src/test/commentTestSamples/issue-111-throw-finally.py
+++ b/src/test/commentTestSamples/issue-111-throw-finally.py
@@ -1,0 +1,7 @@
+# nodes: 4,
+# exits: 1
+def raise_and_finally():
+    try:
+        raise RuntimeError()
+    finally:
+        print("Oh no!")

--- a/src/test/commentTestSamples/issue-111-throw-finally.ts
+++ b/src/test/commentTestSamples/issue-111-throw-finally.ts
@@ -1,0 +1,11 @@
+/*
+nodes: 4,
+exits: 1
+ */
+function throwAndFinally() {
+  try {
+    throw new Error()
+  } finally {
+    console.log("Oh no!")
+  }
+}


### PR DESCRIPTION
- Rename `returns` to `functionExits` to prepare for the functionality change.
- Treat `throw` and `raise` as function-exits for purposes of finally blocks
- Update changelog
- Added tests for raise-finally
- Closes #111