### PR TITLE
Detect non-returning and process-exit functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Documentation now renders `dot` and `dot-cfg` (CFG-styled DOT diagrams)
 - Documentation about our usage of Graphviz
 - Documentation about the representation of control flow in the graph
+- Added support for "special" function detection and process-terminating nodes in the graph.
+  This is currently only enabled in the `/render` page to slowly build up a collection of
+  functions to match and confidence in the representation before adding to the main tool.
 
 ### Fixed
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@types/object-hash": "^3.0.6",
         "@types/vscode": "^1.94.0",
         "@vscode/vsce": "^3.1.1",
+        "core-js": "^3.41.0",
         "esbuild": "^0.25.0",
         "esbuild-plugin-copy": "^2.1.1",
         "graphology": "^0.26.0",
@@ -475,6 +476,8 @@
     "commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "core-js": ["core-js@3.41.0", "", {}, "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA=="],
 
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/object-hash": "^3.0.6",
     "@types/vscode": "^1.94.0",
     "@vscode/vsce": "^3.1.1",
+    "core-js": "^3.41.0",
     "esbuild": "^0.25.0",
     "esbuild-plugin-copy": "^2.1.1",
     "graphology": "^0.26.0",

--- a/src/components/ColorSchemeEditor.svelte
+++ b/src/components/ColorSchemeEditor.svelte
@@ -22,6 +22,7 @@ const colorLabels = new Map([
   ["node.exit", "Exit"],
   ["node.throw", "Throw"],
   ["node.yield", "Yield"],
+  ["node.terminate", "Terminate"],
   ["node.border", "Border"],
   ["node.highlight", "Highlight"],
   ["edge.regular", "Regular"],

--- a/src/control-flow/call-processor.ts
+++ b/src/control-flow/call-processor.ts
@@ -1,0 +1,87 @@
+import type { Node as SyntaxNode } from "web-tree-sitter";
+import type { BasicBlock } from "./cfg-defs.ts";
+import type { Language } from "./cfg.ts";
+import type { Context } from "./generic-cfg-builder.ts";
+import { perLanguageHandlers } from "./per-language-call-handlers.ts";
+import { matchWildcard } from "./wildcard.ts";
+
+export type Is = "TERMINATE" | "ASSERT";
+export type CallHandler = {
+  pattern: string;
+  is: Is;
+};
+
+function matchHandler(
+  functionName: string,
+  handlers: CallHandler[],
+): Is | undefined {
+  return handlers.find(({ pattern }) => matchWildcard(pattern, functionName))
+    ?.is;
+}
+
+export function callProcessorFor(
+  language: Language,
+): CallProcessor | undefined {
+  const handlers = perLanguageHandlers[language];
+  if (!handlers) {
+    return undefined;
+  }
+  return callProcessorFactory(handlers);
+}
+
+export type CallProcessor = (
+  node: SyntaxNode,
+  functionName: string,
+  ctx: Context,
+) => BasicBlock | undefined;
+
+export function callProcessorFactory(handlers: CallHandler[]): CallProcessor {
+  return (
+    node: SyntaxNode,
+    functionName: string,
+    ctx: Context,
+  ): BasicBlock | undefined => {
+    switch (matchHandler(functionName, handlers)) {
+      case "TERMINATE": {
+        const terminateNode = ctx.builder.addNode(
+          "EXIT_PROCESS",
+          `Call to ${functionName}`,
+          node.startIndex,
+        );
+        return {
+          entry: terminateNode,
+          exit: null,
+          functionExits: [terminateNode],
+        };
+      }
+      case "ASSERT": {
+        const conditionNode = ctx.builder.addNode(
+          "ASSERT_CONDITION",
+          `Assert from: ${functionName}`,
+          node.startIndex,
+        );
+        const raiseNode = ctx.builder.addNode(
+          "THROW",
+          `Assert from: ${functionName}`,
+          node.startIndex,
+        );
+        const happyNode = ctx.builder.addNode(
+          "MERGE",
+          "Assert successful",
+          node.startIndex,
+        );
+
+        ctx.builder.addEdge(conditionNode, raiseNode, "alternative");
+        ctx.builder.addEdge(conditionNode, happyNode, "consequence");
+
+        return {
+          entry: conditionNode,
+          exit: happyNode,
+          functionExits: [raiseNode],
+        };
+      }
+      default:
+        return undefined;
+    }
+  };
+}

--- a/src/control-flow/cfg-defs.ts
+++ b/src/control-flow/cfg-defs.ts
@@ -1,5 +1,6 @@
 import type { MultiDirectedGraph } from "graphology";
 import type { Node as SyntaxNode } from "web-tree-sitter";
+import type { Context } from "./generic-cfg-builder.ts";
 import type { Lookup } from "./ranges";
 
 export type NodeType =
@@ -32,7 +33,8 @@ export type NodeType =
   | "FOR_EXIT"
   | "SWITCH_CONDITION"
   | "SWITCH_MERGE"
-  | "CASE_CONDITION";
+  | "CASE_CONDITION"
+  | "EXIT_PROCESS";
 
 export type EdgeType = "regular" | "consequence" | "alternative" | "exception";
 
@@ -290,7 +292,11 @@ export function mergeNodeAttrs(
   if (from.cluster !== into.cluster) {
     return null;
   }
-  const noMergeTypes: Set<NodeType> = new Set(["YIELD", "THROW"]);
+  const noMergeTypes: Set<NodeType> = new Set([
+    "YIELD",
+    "THROW",
+    "EXIT_PROCESS",
+  ]);
   if (noMergeTypes.has(from.type) || noMergeTypes.has(into.type)) {
     return null;
   }
@@ -318,6 +324,11 @@ export interface BuilderOptions {
    * The first capture group will be used as the marker text.
    */
   markerPattern?: RegExp;
+  callProcessor?: (
+    call: SyntaxNode,
+    name: string,
+    ctx: Context,
+  ) => BasicBlock | undefined;
 }
 
 export interface CFGBuilder {

--- a/src/control-flow/colors.ts
+++ b/src/control-flow/colors.ts
@@ -5,6 +5,7 @@ export type ColorList = [
   { name: "node.exit"; hex: string },
   { name: "node.throw"; hex: string },
   { name: "node.yield"; hex: string },
+  { name: "node.terminate"; hex: string },
   { name: "node.border"; hex: string },
   { name: "node.highlight"; hex: string },
   // Edge Colors
@@ -30,6 +31,7 @@ const defaultColorList: ColorList = [
   { name: "node.exit", hex: "#AB3030" },
   { name: "node.throw", hex: "#ffdddd" },
   { name: "node.yield", hex: "#00bfff" },
+  { name: "node.terminate", hex: "#7256c6" },
   { name: "node.border", hex: "#000000" },
   { name: "node.highlight", hex: "#000000" },
 
@@ -55,6 +57,7 @@ const darkColorList: ColorList = [
   { name: "node.exit", hex: "#AB3030" },
   { name: "node.throw", hex: "#590c0c" },
   { name: "node.yield", hex: "#0a9aca" },
+  { name: "node.terminate", hex: "#7256c6" },
   { name: "node.border", hex: "#000000" },
   { name: "node.highlight", hex: "#dddddd" },
   { name: "edge.regular", hex: "#2592a1" },

--- a/src/control-flow/generic-cfg-builder.ts
+++ b/src/control-flow/generic-cfg-builder.ts
@@ -40,6 +40,11 @@ export interface Context {
   state: BlockHandler;
   link: Link;
   extra?: Extra;
+  callProcessor?: (
+    call: SyntaxNode,
+    functionName: string,
+    ctx: Context,
+  ) => BasicBlock | undefined;
 }
 
 /**
@@ -155,6 +160,7 @@ export class GenericCFGBuilder {
         ),
       },
       extra: extra,
+      callProcessor: this.options.callProcessor,
     });
   }
 

--- a/src/control-flow/per-language-call-handlers.ts
+++ b/src/control-flow/per-language-call-handlers.ts
@@ -1,0 +1,11 @@
+import type { CallHandler } from "./call-processor.ts";
+import type { Language } from "./cfg.ts";
+
+export const perLanguageHandlers: Partial<Record<Language, CallHandler[]>> = {
+  Python: [
+    { pattern: "self.assert*", is: "ASSERT" },
+    { pattern: "sys.exit", is: "TERMINATE" },
+    { pattern: "os.abort", is: "TERMINATE" },
+  ],
+  Go: [{ pattern: "panic", is: "TERMINATE" }],
+};

--- a/src/control-flow/render.ts
+++ b/src/control-flow/render.ts
@@ -306,6 +306,8 @@ function renderNode(
     nodeClass = "throw";
   } else if (nodeAttrs.type === "YIELD") {
     nodeClass = "yield";
+  } else if (nodeAttrs.type === "EXIT_PROCESS") {
+    nodeClass = "terminate";
   } else if (graph.degree(node) === 0) {
     // If we only have a single node, we draw it as a default block.
     nodeClass = "default";

--- a/src/control-flow/wildcard.ts
+++ b/src/control-flow/wildcard.ts
@@ -1,0 +1,8 @@
+import "core-js/actual/regexp/escape";
+
+export function matchWildcard(pattern: string, searchString: string): boolean {
+  return new RegExp(
+    // @ts-expect-error `escape` is added by core-js.
+    `^${pattern.split("*").map(RegExp.escape).join(".*")}$`,
+  ).test(searchString);
+}

--- a/src/dot-cfg/theme.ts
+++ b/src/dot-cfg/theme.ts
@@ -5,7 +5,14 @@ import type {
 } from "ts-graphviz";
 import type { ColorScheme } from "../control-flow/colors.ts";
 
-const NodeClasses = ["default", "entry", "exit", "yield", "throw"] as const;
+const NodeClasses = [
+  "default",
+  "entry",
+  "exit",
+  "yield",
+  "throw",
+  "terminate",
+] as const;
 export type NodeClass = (typeof NodeClasses)[number];
 export function isNodeClass(name: string): name is NodeClass {
   return NodeClasses.includes(name as NodeClass);
@@ -50,6 +57,10 @@ const nodeStyles: Record<NodeClass, NodeAttributesObject> = {
     shape: "hexagon",
     orientation: 90,
     class: "yield",
+  },
+  terminate: {
+    shape: "doublecircle",
+    class: "terminate",
   },
 };
 

--- a/src/render/src/App.svelte
+++ b/src/render/src/App.svelte
@@ -4,6 +4,7 @@ import Panzoom, { type PanzoomObject } from "@panzoom/panzoom";
 import { MultiDirectedGraph } from "graphology";
 import { onMount } from "svelte";
 import { type Node as SyntaxNode } from "web-tree-sitter";
+import { callProcessorFor } from "../../control-flow/call-processor";
 import { type Language, newCFGBuilder } from "../../control-flow/cfg";
 import {
   type CFG,
@@ -68,7 +69,10 @@ function parseGithubUrl(githubURL: string): GithubCodeRef {
  * @param language The code language
  */
 function buildCFG(func: SyntaxNode, language: Language): CFG {
-  const builder = newCFGBuilder(language, { flatSwitch: true });
+  const builder = newCFGBuilder(language, {
+    flatSwitch: true,
+    callProcessor: callProcessorFor(language),
+  });
 
   let cfg = builder.buildCFG(func);
 

--- a/src/test/wildcard.test.ts
+++ b/src/test/wildcard.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { matchWildcard } from "../control-flow/wildcard.ts";
+
+test("Exact match", () => {
+  expect(matchWildcard("a", "a")).toBe(true);
+  expect(matchWildcard("a", "b")).toBe(false);
+  expect(matchWildcard("a", "aa")).toBe(false);
+  expect(matchWildcard("a", "ab")).toBe(false);
+  expect(matchWildcard("a", "ba")).toBe(false);
+  expect(matchWildcard("a", "")).toBe(false);
+});
+
+test("Begins with", () => {
+  expect(matchWildcard("a*", "a")).toBe(true);
+  expect(matchWildcard("a*", "abcd")).toBe(true);
+  expect(matchWildcard("a*", "b")).toBe(false);
+  expect(matchWildcard("a*", "ba")).toBe(false);
+});
+
+test("Ends with", () => {
+  expect(matchWildcard("*a", "a")).toBe(true);
+  expect(matchWildcard("*a", "dcba")).toBe(true);
+  expect(matchWildcard("*a", "b")).toBe(false);
+  expect(matchWildcard("*a", "ab")).toBe(false);
+});
+
+test("Starts and ends with", () => {
+  expect(matchWildcard("a*b", "ab")).toBe(true);
+  expect(matchWildcard("a*b", "axxxxxxb")).toBe(true);
+  expect(matchWildcard("a*b", "axxxxxxbx")).toBe(false);
+  expect(matchWildcard("a*b", "xaxxxxxxb")).toBe(false);
+});
+
+test("Contains", () => {
+  expect(matchWildcard("*a*", "a")).toBe(true);
+  expect(matchWildcard("*a*", "xa")).toBe(true);
+  expect(matchWildcard("*a*", "ax")).toBe(true);
+  expect(matchWildcard("*a*", "xax")).toBe(true);
+  expect(matchWildcard("*a*", "xx")).toBe(false);
+});


### PR DESCRIPTION
This is still in research state.

The idea is to use function names only to detect functions that may exit the process instead of returning.

This is things like `panic` in Go, or `os.exit` in Python.

I want to provide sane defaults (mostly fully-qualified names), and allow users to override them via configuration (if we miss something, or if we have false positives)

Closes #114 