### PR TITLE
Exception edges should not count when determining exit nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Multiple `catch` clauses in C++ are now handled properly, even in case of comments between them.
 - Segmentation of `catch` clauses in C++ is now a lot better.
-- Fixed an issue where after sharing and reopening the page, clicking the "Share" button again would default the language back to Go instead of preserving the selected one.
+- Fixed an issue where after sharing and reopening the page,
+  clicking the "Share" button again would default the language back to Go instead of preserving the selected one.
+- Exit nodes are now drawn properly even inside `try` blocks.
 
 ### Changed
 

--- a/src/control-flow/render.ts
+++ b/src/control-flow/render.ts
@@ -294,6 +294,20 @@ function renderEdge(
   return `${source} -> ${target} [${formatStyle(dotAttrs)}];`;
 }
 
+export function isExit(graph: CFGGraph, node: string): boolean {
+  if (graph.outDegree(node) === 0) {
+    return true;
+  }
+  // Exception nodes are invisible and "out-of-band", so they don't affect the
+  // definition of exits.
+  for (const { attributes } of graph.outEdgeEntries(node)) {
+    if (attributes.type !== "exception") {
+      return false;
+    }
+  }
+  return true;
+}
+
 function renderNode(
   graph: CFGGraph,
   node: string,
@@ -313,7 +327,7 @@ function renderNode(
     nodeClass = "default";
   } else if (graph.inDegree(node) === 0) {
     nodeClass = "entry";
-  } else if (graph.outDegree(node) === 0) {
+  } else if (isExit(graph, node)) {
     nodeClass = "exit";
   }
   const dotAttrs = getNodeStyle(nodeClass, context.colorScheme);

--- a/src/test/__snapshots__/commentTest.test.ts.snap
+++ b/src/test/__snapshots__/commentTest.test.ts.snap
@@ -10999,6 +10999,218 @@ Lookup {
 }
 `;
 
+exports[`Python: issue-175-return-from-try.py!lookup_type: DOT Snapshot 1`] = `
+"digraph "" {
+    node [label=""; style="filled"; shape="box"; class="default"; fillcolor="#d3d3d3"; color="#000000"];
+    edge [penwidth=1; color="#0000ff"; headport="n"; tailport="s"];
+    bgcolor="#ffffff";
+
+    subgraph cluster_0 {
+        penwidth=0; class="tryComplex"; color="#ffffff"; bgcolor="#ddddff"
+        subgraph cluster_1 {
+            penwidth=0; class="try"; color="#ffffff"; bgcolor="#ddffdd"
+            node2 [shape="house"; class="exit"; fillcolor="#AB3030"; color="#000000"; height=0.5; id="node2"];
+        }
+        subgraph cluster_2 {
+            penwidth=0; class="except"; color="#ffffff"; bgcolor="#ffdddd"
+            node3 [label=""; style="filled"; shape="box"; class="default"; fillcolor="#d3d3d3"; color="#000000"; height=0.3; id="node3"];
+        }
+    }
+    subgraph cluster_4 {
+        penwidth=0; class="tryComplex"; color="#ffffff"; bgcolor="#ddddff"
+        subgraph cluster_5 {
+            penwidth=0; class="try"; color="#ffffff"; bgcolor="#ddffdd"
+            node5 [shape="house"; class="exit"; fillcolor="#AB3030"; color="#000000"; height=0.5; id="node5"];
+        }
+        subgraph cluster_6 {
+            penwidth=0; class="except"; color="#ffffff"; bgcolor="#ffdddd"
+            node6 [label=""; style="filled"; shape="box"; class="default"; fillcolor="#d3d3d3"; color="#000000"; height=0.3; id="node6"];
+        }
+    }
+    subgraph cluster_8 {
+        penwidth=0; class="tryComplex"; color="#ffffff"; bgcolor="#ddddff"
+        subgraph cluster_9 {
+            penwidth=0; class="try"; color="#ffffff"; bgcolor="#ddffdd"
+            node8 [shape="house"; class="exit"; fillcolor="#AB3030"; color="#000000"; height=0.5; id="node8"];
+        }
+        subgraph cluster_10 {
+            penwidth=0; class="except"; color="#ffffff"; bgcolor="#ffdddd"
+            node9 [label=""; style="filled"; shape="box"; class="default"; fillcolor="#d3d3d3"; color="#000000"; height=0.3; id="node9"];
+        }
+    }
+    node0 [shape="invhouse"; class="entry"; fillcolor="#48AB30"; color="#000000"; height=0.5; id="node0"];
+    node2 [shape="house"; class="exit"; fillcolor="#AB3030"; color="#000000"; height=0.5; id="node2"];
+    node3 [label=""; style="filled"; shape="box"; class="default"; fillcolor="#d3d3d3"; color="#000000"; height=0.3; id="node3"];
+    node1 [label=""; style="filled"; shape="box"; class="default"; fillcolor="#d3d3d3"; color="#000000"; height=0.3; id="node1"];
+    node5 [shape="house"; class="exit"; fillcolor="#AB3030"; color="#000000"; height=0.5; id="node5"];
+    node6 [label=""; style="filled"; shape="box"; class="default"; fillcolor="#d3d3d3"; color="#000000"; height=0.3; id="node6"];
+    node4 [label=""; style="filled"; shape="box"; class="default"; fillcolor="#d3d3d3"; color="#000000"; height=0.3; id="node4"];
+    node8 [shape="house"; class="exit"; fillcolor="#AB3030"; color="#000000"; height=0.5; id="node8"];
+    node9 [label=""; style="filled"; shape="box"; class="default"; fillcolor="#d3d3d3"; color="#000000"; height=0.3; id="node9"];
+    node10 [shape="house"; class="exit"; fillcolor="#AB3030"; color="#000000"; height=0.6; id="node10"];
+    node2 -> node3 [style="invis"; headport="e"; tailport="w"];
+    node3 -> node1 [class="regular"; color="#0000ff"];
+    node5 -> node6 [style="invis"; headport="e"; tailport="w"];
+    node6 -> node4 [class="regular"; color="#0000ff"];
+    node8 -> node9 [style="invis"; headport="e"; tailport="w"];
+    node1 -> node5 [class="regular"; color="#0000ff"];
+    node4 -> node8 [class="regular"; color="#0000ff"];
+    node0 -> node2 [class="regular"; color="#0000ff"];
+    node9 -> node10 [class="regular"; color="#0000ff"];
+}"
+`;
+
+exports[`Python: issue-175-return-from-try.py!lookup_type: Segmentation 1`] = `
+Lookup {
+  "ranges": [
+    {
+      "start": 0,
+      "value": "node0",
+    },
+    {
+      "start": 11,
+      "value": "node0",
+    },
+    {
+      "start": 35,
+      "value": "node2",
+    },
+    {
+      "start": 42,
+      "value": "node2",
+    },
+    {
+      "start": 70,
+      "value": "node2",
+    },
+    {
+      "start": 70,
+      "value": "node2",
+    },
+    {
+      "start": 72,
+      "value": "node3",
+    },
+    {
+      "start": 92,
+      "value": "node3",
+    },
+    {
+      "start": 96,
+      "value": "node3",
+    },
+    {
+      "start": 96,
+      "value": "node3",
+    },
+    {
+      "start": 96,
+      "value": "node2",
+    },
+    {
+      "start": 96,
+      "value": "node5",
+    },
+    {
+      "start": 98,
+      "value": "node0",
+    },
+    {
+      "start": 98,
+      "value": "node5",
+    },
+    {
+      "start": 105,
+      "value": "node5",
+    },
+    {
+      "start": 145,
+      "value": "node5",
+    },
+    {
+      "start": 145,
+      "value": "node5",
+    },
+    {
+      "start": 147,
+      "value": "node6",
+    },
+    {
+      "start": 167,
+      "value": "node6",
+    },
+    {
+      "start": 171,
+      "value": "node6",
+    },
+    {
+      "start": 171,
+      "value": "node6",
+    },
+    {
+      "start": 171,
+      "value": "node5",
+    },
+    {
+      "start": 171,
+      "value": "node8",
+    },
+    {
+      "start": 173,
+      "value": "node0",
+    },
+    {
+      "start": 173,
+      "value": "node8",
+    },
+    {
+      "start": 180,
+      "value": "node8",
+    },
+    {
+      "start": 234,
+      "value": "node8",
+    },
+    {
+      "start": 234,
+      "value": "node8",
+    },
+    {
+      "start": 236,
+      "value": "node9",
+    },
+    {
+      "start": 256,
+      "value": "node9",
+    },
+    {
+      "start": 260,
+      "value": "node9",
+    },
+    {
+      "start": 260,
+      "value": "node9",
+    },
+    {
+      "start": 260,
+      "value": "node8",
+    },
+    {
+      "start": 260,
+      "value": "node0",
+    },
+    {
+      "start": 260,
+      "value": "node8",
+    },
+    {
+      "start": 260,
+      "value": "node0",
+    },
+  ],
+}
+`;
+
 exports[`Python: sample.py!For: DOT Snapshot 1`] = `
 "digraph "" {
     node [label=""; style="filled"; shape="box"; class="default"; fillcolor="#d3d3d3"; color="#000000"];

--- a/src/test/commentTestHandlers.ts
+++ b/src/test/commentTestHandlers.ts
@@ -11,7 +11,7 @@ import {
   mergeNodeAttrs,
 } from "../control-flow/cfg-defs";
 import { simplifyCFG, trimFor } from "../control-flow/graph-ops";
-import { graphToDot } from "../control-flow/render";
+import { graphToDot, isExit } from "../control-flow/render";
 import type { Requirements, TestFunction } from "./commentTestTypes";
 
 const markerPattern: RegExp = /CFG: (\w+)/;
@@ -111,8 +111,8 @@ export const requirementTests: Record<keyof Requirements, RequirementHandler> =
     exits(testFunc: TestFunction) {
       if (testFunc.reqs.exits !== undefined) {
         const cfg = buildSimpleCFG(testFunc.language, testFunc.function);
-        const exitNodes = cfg.graph.filterNodes(
-          (node) => cfg.graph.outDegree(node) === 0,
+        const exitNodes = cfg.graph.filterNodes((node) =>
+          isExit(cfg.graph, node),
         );
         if (exitNodes.length !== testFunc.reqs.exits) {
           return `expected ${testFunc.reqs.exits} exits but found ${exitNodes.length}`;

--- a/src/test/commentTestSamples/issue-175-return-from-try.py
+++ b/src/test/commentTestSamples/issue-175-return-from-try.py
@@ -1,0 +1,14 @@
+# exits: 4
+def lookup_type(name):
+	try:
+		return gdb.lookup_type(name)
+	except gdb.error:
+		pass
+	try:
+		return gdb.lookup_type('struct ' + name)
+	except gdb.error:
+		pass
+	try:
+		return gdb.lookup_type('struct ' + name[1:]).pointer()
+	except gdb.error:
+		pass

--- a/src/test/commentTestSamples/sample.py
+++ b/src/test/commentTestSamples/sample.py
@@ -163,7 +163,7 @@ def raise_exception():
     raise
 
 # render: true,
-# exits: 1,
+# exits: 2,
 # nodes: 6
 def raise_again():
     try:


### PR DESCRIPTION
Changes the criteria for exit nodes to either
have outdegree==0, or only have exception edges.

Closes #175.

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the `bun lint` on the code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] For visual changes, I've added screenshots to the PR.
- [ ] I accept that @tmr232 may be pedantic in the code review.

## Description

Exit nodes are now rendered correctly inside `try` blocks.

Example for the following code:

```python
def lookup_type(name):
	try:
		return gdb.lookup_type(name)
	except gdb.error:
		pass
	try:
		return gdb.lookup_type('struct ' + name)
	except gdb.error:
		pass
	try:
		return gdb.lookup_type('struct ' + name[1:]).pointer()
	except gdb.error:
		pass
```

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/7d42d457-d7cf-4798-9962-b1079d523dc9) |  ![image](https://github.com/user-attachments/assets/eb8c411a-0b3c-49d0-b0a0-2abc9ef1743e) |


